### PR TITLE
[v2] Implement usb-auto-passthrough policy

### DIFF
--- a/src/devstore.c
+++ b/src/devstore.c
@@ -529,6 +529,13 @@ static int findDeviceRoute(DevInfo *device, int dom_id)
                 if (is_usb_enabled(dom_id))
                 {
                     LogInfo("SSSS domid=%d is_usb_enabled=true", dom_id);
+
+                    /* Check USB auto-passthrough policy. If not allowed, retain device in Dom0 */
+                    if(!is_usb_auto_passthrough(dom_id))
+                    {
+                        dom_id = DEV_VM_DOM0;
+                        uuid = DOM0_UUID;
+                    }
                 }
                 else
                 {

--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -18,6 +18,7 @@
 
 /* rpc.c */
 extern gboolean is_usb_enabled(int domid);
+extern gboolean is_usb_auto_passthrough(int domid);
 extern gboolean has_device_grab(int domid);
 extern xcdbus_conn_t *rpc_xcbus(void);
 extern int remote_plug_device(int domid, int bus_num, int dev_num);

--- a/src/rpc.c
+++ b/src/rpc.c
@@ -46,6 +46,19 @@ gboolean is_usb_enabled(int domid)
     return v;
 }
 
+gboolean is_usb_auto_passthrough(int domid)
+{
+    char *obj_path = NULL;
+    gboolean v;
+    if (!com_citrix_xenclient_xenmgr_find_vm_by_domid_ ( g_xcbus, "com.citrix.xenclient.xenmgr", "/", domid, &obj_path )) {
+        return 0;
+    }
+    if (!property_get_com_citrix_xenclient_xenmgr_vm_usb_auto_passthrough_ ( g_xcbus, "com.citrix.xenclient.xenmgr", obj_path, &v )) {
+        return 0;
+    }
+    return v;
+}
+
 gboolean has_device_grab(int domid)
 {
     char *obj_path = NULL;


### PR DESCRIPTION
Check the usb-auto-passthrough VM property. If not allowed (set to
false), retain USB device in Dom0.

OXT-64

Signed-off-by: Kevin Pearson kevin.pearson.4@us.af.mil
