### PR TITLE
[vusb] Do not auto-assign devices to VMs with no tools X 2

### DIFF
--- a/src/devstore.c
+++ b/src/devstore.c
@@ -535,10 +535,8 @@ static int findDeviceRoute(DevInfo *device, int dom_id)
                     {
                         dom_id = DEV_VM_DOM0;
                         uuid = DOM0_UUID;
-                    }
-
-                    /* Check USB auto-passthrough policy. If not allowed, retain device in Dom0 */
-                    if(!is_usb_auto_passthrough(dom_id))
+                    } /* Check USB auto-passthrough policy. If not allowed, retain device in Dom0 */
+                    else if(!is_usb_auto_passthrough(dom_id))
                     {
                         dom_id = DEV_VM_DOM0;
                         uuid = DOM0_UUID;


### PR DESCRIPTION
This is a slight modification that puts the second check
for is_usb_auto_passthrough in an "else if" so domid 0
is not passed to xenmgr where it causes an error.

OXT-117

Signed-off-by: Ross Philipson <ross.philipson@gmail.com>