### PR TITLE
[vusb] Do not auto-assign devices to VMs with no tools - fixed

### DIFF
--- a/src/devstore.c
+++ b/src/devstore.c
@@ -530,15 +530,10 @@ static int findDeviceRoute(DevInfo *device, int dom_id)
                 {
                     LogInfo("SSSS domid=%d is_usb_enabled=true", dom_id);
 
-                    /* Tools installed? If not, don't asssign, retain device in Dom0 */
-                    if(!has_pv_addons(dom_id))
-                    {
-                        dom_id = DEV_VM_DOM0;
-                        uuid = DOM0_UUID;
-                    }
-
-                    /* Check USB auto-passthrough policy. If not allowed, retain device in Dom0 */
-                    if(!is_usb_auto_passthrough(dom_id))
+                    /* Tools installed? If not, don't asssign, retain device in Dom0
+                     * Or
+                     * Check USB auto-passthrough policy. If not allowed, retain device in Dom0 */
+                    if(!has_pv_addons(dom_id) || !is_usb_auto_passthrough(dom_id))
                     {
                         dom_id = DEV_VM_DOM0;
                         uuid = DOM0_UUID;


### PR DESCRIPTION
Ok this time use an OR to prevent submitting domid == 0 to xenmgr
which causes an error.

OXT-117

Signed-off-by: Ross Philipson <ross.philipson@gmail.com>