### PR TITLE
[vusb] Domain ID not being set in device object.

### DIFF
--- a/src/devstore.c
+++ b/src/devstore.c
@@ -601,6 +601,9 @@ static void routeDevice(DevInfo *device, int dom_id)
     }
 
     remote_report_dev_change(device->id);
+
+    device->VM = routed_dom_id;
+    LogInfo("Device id: %d routed to domain id: %d", device->id, device->VM);
 }
 
 

--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -98,7 +98,8 @@ extern void dumpVMs(Buffer *buffer);
 extern const char *VMid2uuid(int domid);
 extern int VMuuid2id(const char *uuid);
 /* sys.c */
-extern void bindToDom0(const char *sysName);
+extern void __bindToDom0(const char *caller, const char *sysName);
+#define bindToDom0(s) __bindToDom0(__FUNCTION__, (s))
 extern int bindToUsbhid(const char *bus_id);
 extern void unbindAllFromDom0(const char *sysName);
 extern void unbindAllFromDom0ExceptRootDevice(const char *sysName);

--- a/src/sys.c
+++ b/src/sys.c
@@ -156,7 +156,7 @@ static int catFileString(const char *dir, const char *file, Buffer *buffer)
 /* Bind all the single given device or interface to dom0 drivers
  * param    sysName              device or interface's system name
  */
-void bindToDom0(const char *sysName)
+void __bindToDom0(const char *caller, const char *sysName)
 {
     FILE *file;
 
@@ -170,7 +170,7 @@ void bindToDom0(const char *sysName)
         return;
     }
 
-    LogInfo("Binding %s to dom0", sysName);
+    LogInfo("Caller %s: binding %s to dom0", caller, sysName);
     fprintf(file, "%s", sysName);
     fclose(file);
 }


### PR DESCRIPTION
There was a change to the vusb_daemon in the space between when it was forked
off the ctxusb_daemon and when it went into OpenXT. In this fix, the setting
of the device->VM field was lost. This problem caused further binding calls
for interfaces for DOM0 devices to not occur and thus prevented udev from
completing its probe operations. This is why all the other nodes (/dev/sxx,
 /sys/class/bsg, etc) were not created and why the problem is not seen in
XCXT 4.0.

OXT-73

Signed-off-by: Ross Philipson <philipsonr@ainfosec.com>