### PR TITLE
OXT-222

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -92,6 +92,11 @@ static int watch(void)
     return 2;
 }                                          
 
+void cleanup(int sig_num)
+{
+	wait();
+}
+
 
 int main(int argc, char **argv)
 {
@@ -101,6 +106,7 @@ int main(int argc, char **argv)
         return 1;
     }
 
+	signal(SIGCHLD, cleanup);
     /* Initialise stuff */
     event_init();
     xenstore_init();

--- a/src/rpc.c
+++ b/src/rpc.c
@@ -297,6 +297,14 @@ void remote_report_dev_change(int dev_id)
                                                               "/", dev_id);
 }
 
+void remote_report_host_refresh_request(int dev_id)
+{
+    assert(g_glib_dbus_conn != NULL);
+    notify_com_citrix_xenclient_usbdaemon_host_refresh(g_xcbus,
+                                                       "com.citrix.xenclient.usbdaemon", 
+	                                                   "/");
+}
+
 
 void rpc_init()
 {


### PR DESCRIPTION
OXT-222

Add support to signal a host refresh in the UI after a usb device has
been recognized as a CD device.

Signed-off by: Chris Rogers rogersc@ainfosec.com