### PR TITLE
Send signal to refresh host UI after usb device is recognized as CD

### DIFF
--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -28,6 +28,7 @@ extern int remote_query_devices(int domid, IBuffer *device_ids);
 extern void remote_report_rejected(const char *dev_name, const char *cause);
 extern void remote_report_all_devs_change(void);
 extern void remote_report_dev_change(int dev_id);
+extern void remote_report_optical_device_detected(void);
 extern void rpc_init(void);
 /* main.c */
 extern int main(int argc, char **argv);

--- a/src/rpc.c
+++ b/src/rpc.c
@@ -297,6 +297,14 @@ void remote_report_dev_change(int dev_id)
                                                               "/", dev_id);
 }
 
+void remote_report_optical_device_detected()
+{
+    assert(g_glib_dbus_conn != NULL);
+    notify_com_citrix_xenclient_usbdaemon_optical_device_detected(g_xcbus,
+                                                                  "com.citrix.xenclient.usbdaemon", 
+                                                                  "/");
+}
+
 
 void rpc_init()
 {

--- a/src/sys.c
+++ b/src/sys.c
@@ -1317,6 +1317,22 @@ void udevMonHandler(void)
             trimEndBuffer(&device, ':');
             processNewHidraw(endPath, device.data);
         }
+        else if(type != NULL && strcmp(type, "disk") == 0)
+        {
+            const char *id_type = udev_device_get_property_value(dev, "ID_CDROM");
+
+            /* New optical device detected
+             * At this point, send dbus signal to refresh
+             * the host model in the ui so the usb device
+             * appears properly as a cd device automatically.
+             */
+            if(id_type != NULL && strcmp(id_type, "1") == 0)
+            {
+                LogInfo("Detected new optical device %s", endPath);
+                remote_report_optical_device_detected();
+            }
+        }
+
     }
     else if(action != NULL && strcmp(action, "remove") == 0)
     {
@@ -1386,6 +1402,7 @@ int initSys(void)
     udev_monitor_filter_add_match_subsystem_devtype(udev_mon, "usb", NULL);
     udev_monitor_filter_add_match_subsystem_devtype(udev_mon, "scsi", NULL);
     udev_monitor_filter_add_match_subsystem_devtype(udev_mon, "hidraw", NULL);
+    udev_monitor_filter_add_match_subsystem_devtype(udev_mon, "block", NULL);
     udev_monitor_enable_receiving(udev_mon);
     udev_fd = udev_monitor_get_fd(udev_mon);
 


### PR DESCRIPTION
Add support to signal a host refresh in the UI after a usb device has
been recognized as a CD device.  Adds a new udev event to watch for
"bsg", upon which triggers the dbus call.

OXT-222

Signed-off by: Chris Rogers rogersc@ainfosec.com